### PR TITLE
Add CI workflow for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: CI
+
+env:
+  PROJECT: OPTIONAL_FUN_LITE
+
+on:
+  push:
+    branches: [ master ]
+
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  gcc:
+    strategy:
+      matrix:
+        version: [9, 10, 11]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install GCC ${{ matrix.version }}
+        run: sudo apt-get install -y gcc-${{ matrix.version }} g++-${{ matrix.version }}
+
+      - name: Configure tests
+        env:
+          CXX: g++-${{ matrix.version }}
+        run: cmake -S . -B build
+          -D CMAKE_BUILD_TYPE:STRING=Release
+          -D ${{ env.PROJECT }}_OPT_SELECT_NONSTD=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_TESTS=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_EXAMPLES=OFF
+
+      - name: Build tests
+        run: cmake --build build -j 4
+
+      - name: Run tests
+        working-directory: build
+        run: ctest --output-on-failure -j 4
+
+  clang:
+    strategy:
+      matrix:
+        version: [11, 12]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Clang ${{ matrix.version }}
+        run: sudo apt-get install -y clang-${{ matrix.version }}
+
+      - name: Configure tests
+        env:
+          CXX: clang-${{ matrix.version }}
+        run: cmake -S . -B build
+          -D CMAKE_CXX_COMPILER=clang++
+          -D CMAKE_BUILD_TYPE:STRING=Release
+          -D ${{ env.PROJECT }}_OPT_SELECT_NONSTD=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_TESTS=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_EXAMPLES=OFF
+
+      - name: Build tests
+        run: cmake --build build -j 4
+
+      - name: Run tests
+        working-directory: build
+        run: ctest --output-on-failure -j 4
+
+  msvc:
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure tests
+        run: cmake -S . -B build
+          -D ${{ env.PROJECT }}_OPT_SELECT_NONSTD=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_TESTS=ON
+          -D ${{ env.PROJECT }}_OPT_BUILD_EXAMPLES=OFF
+
+      - name: Build tests
+        run: cmake --build build --config Release -j 4
+
+      - name: Run tests
+        working-directory: build
+        run: ctest -C Release --output-on-failure -j 4


### PR DESCRIPTION
It's based on the workflow file of bit-lite (https://github.com/martinmoene/bit-lite/blob/master/.github/workflows/ci.yml), so it probably should work without further changes.


As a side effect, this PR also contributes to https://github.com/martinmoene/nonstd-lite-project/issues/70 by providing a workflow that already has the newer version of `actions/checkout`.